### PR TITLE
Don't ignore the ignore file, but do ignore the config file. :-)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 .*.swp
 Thumbs.db
 /nbproject
-.gitignore
+config.php


### PR DESCRIPTION
The `.gitignore` file shouldn't be ignored (and in fact I don't think it can be, so listing it has no effect), but the `config.php` file should be ignored, to avoid accidental distribution and to keep `git status` cleaner.
