### PR TITLE
Login failure message

### DIFF
--- a/error.php
+++ b/error.php
@@ -27,7 +27,7 @@ $last_message = (isset($_REQUEST['last_message']) ? $_REQUEST['last_message'] : 
 
 draw_header(msg('error'), $last_message);
 
-if(isset($_REQUEST['ec']) && (int) $_REQUEST['ec'])
+if (isset($_REQUEST['ec']) && intval($_REQUEST['ec']) >= 0)
 {
     switch ($_REQUEST['ec'])
     {


### PR DESCRIPTION
This changes the error-code check to account for the `0` error code (i.e. `message_there_was_an_error_loggin_you_in`). Because 0 == FALSE in PHP, it wasn't working.
