### PR TITLE
Update database.sql

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -56,7 +56,7 @@ CREATE TABLE odm_data (
   category int(11) unsigned NOT NULL default '0',
   owner int(11) unsigned default NULL,
   realname varchar(255) NOT NULL default '',
-  created datetime NOT NULL default '0000-00-00 00:00:00',
+  created datetime NOT NULL default '1000-01-01 00:00:00',
   description varchar(255) default NULL,
   comment varchar(255) default '',
   status smallint(6) default NULL,
@@ -132,7 +132,7 @@ INSERT INTO odm_dept_reviewer VALUES (1,1);
 
 CREATE TABLE odm_log (
   id int(11) unsigned NOT NULL default '0',
-  modified_on datetime NOT NULL default '0000-00-00 00:00:00',
+  modified_on datetime NOT NULL default '1000-01-01 00:00:00',
   modified_by varchar(25) default NULL,
   note text,
   revision varchar(255) default NULL,


### PR DESCRIPTION
Hi, I'm running ODM on a new install of Ubuntu 16.04, which has php7 and mysql 5.7.12

this version of mysql has changed the minimum value for the timestamp datatype (as per https://dev.mysql.com/doc/refman/5.5/en/datetime.html)

The new minimum value is 1000-01-01 00:00:00 which makes the default for odm_data and odm_log invalid and the tables were not created in running the install script. I have amended the default value for the relevant fields in those two files which has allowed the script to run properly.

Peter