### PR TITLE
CSS JS load issue when installed in directory

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -891,7 +891,7 @@ function base_url(){
         return sprintf(
             "%s://%s",
             $proto,
-            $_SERVER['HTTP_HOST'].dirname($_SERVER['REQUEST_URI'])
+            $_SERVER['HTTP_HOST'].dirname($_SERVER['SCRIPT_NAME'])
         );
     } else {
         // Set the base url relative to the plug-ins folder when being called from there


### PR DESCRIPTION
for ```https://mydomain.com/dir/index.php``` dirname($_SERVER['SCRIPT_NAME']) returns /dir

for ```https://mydomain.com/dir``` dirname($_SERVER['SCRIPT_NAME']) returns blank 

when opendocman is installed in directory and accessed by ```https://mydomain.com/dir``` like url css js doesn't load because of wrong url