### PR TITLE
chore: add .opencode skill, gitignore .playwright-mcp, fix release-please marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ php-server.log
 node_modules/
 playwright-report/
 test-results/
+.playwright-mcp/

--- a/.opencode/skills/webapp-testing/SKILL.md
+++ b/.opencode/skills/webapp-testing/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: webapp-testing
+description: Test local web applications with Playwright and server helpers.
+license: MIT
+compatibility: opencode
+---
+
+## What I do
+- Run native Python or Node.js Playwright scripts to control a real browser.
+- Start local servers using a test-runner wrapper.
+- Wait for network idle before inspecting the DOM.
+- Capture screenshots, network tracking, and browser logs.
+- Use a "reconnaissance-then-action" workflow (inspecting the elements before interacting).
+
+## When to use me
+Use this when asked to smoke test, run E2E/UAT journeys, or debug failing UI flows on a live web application.

--- a/application/version.php
+++ b/application/version.php
@@ -17,7 +17,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-const ODM_APP_VERSION = '2.1.0';//x-release-please-version
+const ODM_APP_VERSION = '2.1.0';// x-release-please-version
 const ODM_DB_VERSION = '1.4.1';
 
 // version information


### PR DESCRIPTION
- Add webapp-testing skill to `.opencode/skills/`
- Ignore `.playwright-mcp/` debug artifacts
- Fix release-please version marker (add space after `//`)

The `//x-release-please-version` marker was missing a space, so Release Please silently skipped `application/version.php` on releases. Fixed to `// x-release-please-version`.